### PR TITLE
Bump Version for Xcode Cloud

### DIFF
--- a/imastodon-mac/Info.plist
+++ b/imastodon-mac/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>37</string>
 	<key>LSApplicationCategoryType</key>

--- a/imastodon/Info.plist
+++ b/imastodon/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
 	<string>37</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
Xcode Cloud is very smart enough to manage build numbers automatically based on its `Build` numbers in terms of Xcode Cloud itself, i.e. starting from 1 and cannot be customizable, and that cause `ITMS-90189: Redundant Binary Upload` error against an App Store Connect requirement. really nice collision.